### PR TITLE
Add Meetup exercise implementation and tests

### DIFF
--- a/meetup/README.md
+++ b/meetup/README.md
@@ -1,0 +1,89 @@
+# Meetup
+
+Welcome to Meetup on Exercism's Scala Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Introduction
+
+Every month, your partner meets up with their best friend.
+Both of them have very busy schedules, making it challenging to find a suitable date!
+Given your own busy schedule, your partner always double-checks potential meetup dates with you:
+
+- "Can I meet up on the first Friday of next month?"
+- "What about the third Wednesday?"
+- "Maybe the last Sunday?"
+
+In this month's call, your partner asked you this question:
+
+- "I'd like to meet up on the teenth Thursday; is that okay?"
+
+Confused, you ask what a "teenth" day is.
+Your partner explains that a teenth day, a concept they made up, refers to the days in a month that end in '-teenth':
+
+- 13th (thirteenth)
+- 14th (fourteenth)
+- 15th (fifteenth)
+- 16th (sixteenth)
+- 17th (seventeenth)
+- 18th (eighteenth)
+- 19th (nineteenth)
+
+As there are also seven weekdays, it is guaranteed that each day of the week has _exactly one_ teenth day each month.
+
+Now that you understand the concept of a teenth day, you check your calendar.
+You don't have anything planned on the teenth Thursday, so you happily confirm the date with your partner.
+
+## Instructions
+
+Your task is to find the exact date of a meetup, given a month, year, weekday and week.
+
+There are five week values to consider: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
+
+For example, you might be asked to find the date for the meetup on the first Monday in January 2018 (January 1, 2018).
+
+Similarly, you might be asked to find:
+
+- the third Tuesday of August 2019 (August 20, 2019)
+- the teenth Wednesday of May 2020 (May 13, 2020)
+- the fourth Sunday of July 2021 (July 25, 2021)
+- the last Thursday of November 2022 (November 24, 2022)
+- the teenth Saturday of August 1953 (August 15, 1953)
+
+## Teenth
+
+The teenth week refers to the seven days in a month that end in '-teenth' (13th, 14th, 15th, 16th, 17th, 18th and 19th).
+
+If asked to find the teenth Saturday of August, 1953, we check its calendar:
+
+```plaintext
+    August 1953
+Su Mo Tu We Th Fr Sa
+                   1
+ 2  3  4  5  6  7  8
+ 9 10 11 12 13 14 15
+16 17 18 19 20 21 22
+23 24 25 26 27 28 29
+30 31
+```
+
+From this we find that the teenth Saturday is August 15, 1953.
+
+## Source
+
+### Created by
+
+- @sgrif
+
+### Contributed to by
+
+- @abo64
+- @ErikSchierboom
+- @jmtuley
+- @kytrinyx
+- @ppartarr
+- @rajeshpg
+- @ricemery
+
+### Based on
+
+Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month

--- a/meetup/build.sbt
+++ b/meetup/build.sbt
@@ -1,0 +1,3 @@
+scalaVersion := "3.4.2"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test

--- a/meetup/project/build.properties
+++ b/meetup/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.11

--- a/meetup/src/main/scala/Meetup.scala
+++ b/meetup/src/main/scala/Meetup.scala
@@ -1,0 +1,34 @@
+import Schedule.Schedule
+
+import java.time.temporal.TemporalAdjusters.{dayOfWeekInMonth, firstInMonth, lastInMonth, nextOrSame}
+import java.time.{DayOfWeek, LocalDate, Year}
+
+case class Meetup(month: Int, year: Int) {
+
+  def day(day: Int, schedule: Schedule): LocalDate =
+    val dayOfWeek = DayOfWeek.of(day)
+    val adjuster = schedule match {
+      case Schedule.First => firstInMonth(dayOfWeek)
+      case Schedule.Second => dayOfWeekInMonth(2, dayOfWeek)
+      case Schedule.Third => dayOfWeekInMonth(3, dayOfWeek)
+      case Schedule.Fourth => dayOfWeekInMonth(4, dayOfWeek)
+      case Schedule.Teenth => nextOrSame(dayOfWeek)
+      case Schedule.Last => lastInMonth(dayOfWeek)
+    }
+    Year.of(year).atMonth(month).atDay(13) `with` adjuster
+}
+
+object Schedule extends Enumeration {
+  type Schedule = Value
+  val Teenth, First, Second, Third, Fourth, Last = Value
+}
+
+object Meetup {
+  val Mon = DayOfWeek.MONDAY.getValue
+  val Tue = DayOfWeek.TUESDAY.getValue
+  val Wed = DayOfWeek.WEDNESDAY.getValue
+  val Thu = DayOfWeek.THURSDAY.getValue
+  val Fri = DayOfWeek.FRIDAY.getValue
+  val Sat = DayOfWeek.SATURDAY.getValue
+  val Sun = DayOfWeek.SUNDAY.getValue
+}

--- a/meetup/src/test/scala/MeetupTest.scala
+++ b/meetup/src/test/scala/MeetupTest.scala
@@ -1,0 +1,484 @@
+import java.time.LocalDate
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+
+/** @version 1.1.0 */
+class MeetupTest extends AnyFunSuite with Matchers {
+
+  test("monteenth of May 2013") {
+    Meetup(5, 2013).day(Meetup.Mon, Schedule.Teenth) should be(
+      LocalDate.of(2013, 5, 13))
+  }
+
+  test("monteenth of August 2013") {
+    Meetup(8, 2013).day(Meetup.Mon, Schedule.Teenth) should be(
+      LocalDate.of(2013, 8, 19))
+  }
+
+  test("monteenth of September 2013") {
+    Meetup(9, 2013).day(Meetup.Mon, Schedule.Teenth) should be(
+      LocalDate.of(2013, 9, 16))
+  }
+
+  test("tuesteenth of March 2013") {
+    Meetup(3, 2013).day(Meetup.Tue, Schedule.Teenth) should be(
+      LocalDate.of(2013, 3, 19))
+  }
+
+  test("tuesteenth of April 2013") {
+    Meetup(4, 2013).day(Meetup.Tue, Schedule.Teenth) should be(
+      LocalDate.of(2013, 4, 16))
+  }
+
+  test("tuesteenth of August 2013") {
+    Meetup(8, 2013).day(Meetup.Tue, Schedule.Teenth) should be(
+      LocalDate.of(2013, 8, 13))
+  }
+
+  test("wednesteenth of January 2013") {
+    Meetup(1, 2013).day(Meetup.Wed, Schedule.Teenth) should be(
+      LocalDate.of(2013, 1, 16))
+  }
+
+  test("wednesteenth of February 2013") {
+    Meetup(2, 2013).day(Meetup.Wed, Schedule.Teenth) should be(
+      LocalDate.of(2013, 2, 13))
+  }
+
+  test("wednesteenth of June 2013") {
+    Meetup(6, 2013).day(Meetup.Wed, Schedule.Teenth) should be(
+      LocalDate.of(2013, 6, 19))
+  }
+
+  test("thursteenth of May 2013") {
+    Meetup(5, 2013).day(Meetup.Thu, Schedule.Teenth) should be(
+      LocalDate.of(2013, 5, 16))
+  }
+
+  test("thursteenth of June 2013") {
+    Meetup(6, 2013).day(Meetup.Thu, Schedule.Teenth) should be(
+      LocalDate.of(2013, 6, 13))
+  }
+
+  test("thursteenth of September 2013") {
+    Meetup(9, 2013).day(Meetup.Thu, Schedule.Teenth) should be(
+      LocalDate.of(2013, 9, 19))
+  }
+
+  test("friteenth of April 2013") {
+    Meetup(4, 2013).day(Meetup.Fri, Schedule.Teenth) should be(
+      LocalDate.of(2013, 4, 19))
+  }
+
+  test("friteenth of August 2013") {
+    Meetup(8, 2013).day(Meetup.Fri, Schedule.Teenth) should be(
+      LocalDate.of(2013, 8, 16))
+  }
+
+  test("friteenth of September 2013") {
+    Meetup(9, 2013).day(Meetup.Fri, Schedule.Teenth) should be(
+      LocalDate.of(2013, 9, 13))
+  }
+
+  test("saturteenth of February 2013") {
+    Meetup(2, 2013).day(Meetup.Sat, Schedule.Teenth) should be(
+      LocalDate.of(2013, 2, 16))
+  }
+
+  test("saturteenth of April 2013") {
+    Meetup(4, 2013).day(Meetup.Sat, Schedule.Teenth) should be(
+      LocalDate.of(2013, 4, 13))
+  }
+
+  test("saturteenth of October 2013") {
+    Meetup(10, 2013).day(Meetup.Sat, Schedule.Teenth) should be(
+      LocalDate.of(2013, 10, 19))
+  }
+
+  test("sunteenth of May 2013") {
+    Meetup(5, 2013).day(Meetup.Sun, Schedule.Teenth) should be(
+      LocalDate.of(2013, 5, 19))
+  }
+
+  test("sunteenth of June 2013") {
+    Meetup(6, 2013).day(Meetup.Sun, Schedule.Teenth) should be(
+      LocalDate.of(2013, 6, 16))
+  }
+
+  test("sunteenth of October 2013") {
+    Meetup(10, 2013).day(Meetup.Sun, Schedule.Teenth) should be(
+      LocalDate.of(2013, 10, 13))
+  }
+
+  test("first Monday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Mon, Schedule.First) should be(
+      LocalDate.of(2013, 3, 4))
+  }
+
+  test("first Monday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Mon, Schedule.First) should be(
+      LocalDate.of(2013, 4, 1))
+  }
+
+  test("first Tuesday of May 2013") {
+    Meetup(5, 2013).day(Meetup.Tue, Schedule.First) should be(
+      LocalDate.of(2013, 5, 7))
+  }
+
+  test("first Tuesday of June 2013") {
+    Meetup(6, 2013).day(Meetup.Tue, Schedule.First) should be(
+      LocalDate.of(2013, 6, 4))
+  }
+
+  test("first Wednesday of July 2013") {
+    Meetup(7, 2013).day(Meetup.Wed, Schedule.First) should be(
+      LocalDate.of(2013, 7, 3))
+  }
+
+  test("first Wednesday of August 2013") {
+    Meetup(8, 2013).day(Meetup.Wed, Schedule.First) should be(
+      LocalDate.of(2013, 8, 7))
+  }
+
+  test("first Thursday of September 2013") {
+    Meetup(9, 2013).day(Meetup.Thu, Schedule.First) should be(
+      LocalDate.of(2013, 9, 5))
+  }
+
+  test("first Thursday of October 2013") {
+    Meetup(10, 2013).day(Meetup.Thu, Schedule.First) should be(
+      LocalDate.of(2013, 10, 3))
+  }
+
+  test("first Friday of November 2013") {
+    Meetup(11, 2013).day(Meetup.Fri, Schedule.First) should be(
+      LocalDate.of(2013, 11, 1))
+  }
+
+  test("first Friday of December 2013") {
+    Meetup(12, 2013).day(Meetup.Fri, Schedule.First) should be(
+      LocalDate.of(2013, 12, 6))
+  }
+
+  test("first Saturday of January 2013") {
+    Meetup(1, 2013).day(Meetup.Sat, Schedule.First) should be(
+      LocalDate.of(2013, 1, 5))
+  }
+
+  test("first Saturday of February 2013") {
+    Meetup(2, 2013).day(Meetup.Sat, Schedule.First) should be(
+      LocalDate.of(2013, 2, 2))
+  }
+
+  test("first Sunday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Sun, Schedule.First) should be(
+      LocalDate.of(2013, 3, 3))
+  }
+
+  test("first Sunday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Sun, Schedule.First) should be(
+      LocalDate.of(2013, 4, 7))
+  }
+
+  test("second Monday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Mon, Schedule.Second) should be(
+      LocalDate.of(2013, 3, 11))
+  }
+
+  test("second Monday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Mon, Schedule.Second) should be(
+      LocalDate.of(2013, 4, 8))
+  }
+
+  test("second Tuesday of May 2013") {
+    Meetup(5, 2013).day(Meetup.Tue, Schedule.Second) should be(
+      LocalDate.of(2013, 5, 14))
+  }
+
+  test("second Tuesday of June 2013") {
+    Meetup(6, 2013).day(Meetup.Tue, Schedule.Second) should be(
+      LocalDate.of(2013, 6, 11))
+  }
+
+  test("second Wednesday of July 2013") {
+    Meetup(7, 2013).day(Meetup.Wed, Schedule.Second) should be(
+      LocalDate.of(2013, 7, 10))
+  }
+
+  test("second Wednesday of August 2013") {
+    Meetup(8, 2013).day(Meetup.Wed, Schedule.Second) should be(
+      LocalDate.of(2013, 8, 14))
+  }
+
+  test("second Thursday of September 2013") {
+    Meetup(9, 2013).day(Meetup.Thu, Schedule.Second) should be(
+      LocalDate.of(2013, 9, 12))
+  }
+
+  test("second Thursday of October 2013") {
+    Meetup(10, 2013).day(Meetup.Thu, Schedule.Second) should be(
+      LocalDate.of(2013, 10, 10))
+  }
+
+  test("second Friday of November 2013") {
+    Meetup(11, 2013).day(Meetup.Fri, Schedule.Second) should be(
+      LocalDate.of(2013, 11, 8))
+  }
+
+  test("second Friday of December 2013") {
+    Meetup(12, 2013).day(Meetup.Fri, Schedule.Second) should be(
+      LocalDate.of(2013, 12, 13))
+  }
+
+  test("second Saturday of January 2013") {
+    Meetup(1, 2013).day(Meetup.Sat, Schedule.Second) should be(
+      LocalDate.of(2013, 1, 12))
+  }
+
+  test("second Saturday of February 2013") {
+    Meetup(2, 2013).day(Meetup.Sat, Schedule.Second) should be(
+      LocalDate.of(2013, 2, 9))
+  }
+
+  test("second Sunday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Sun, Schedule.Second) should be(
+      LocalDate.of(2013, 3, 10))
+  }
+
+  test("second Sunday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Sun, Schedule.Second) should be(
+      LocalDate.of(2013, 4, 14))
+  }
+
+  test("third Monday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Mon, Schedule.Third) should be(
+      LocalDate.of(2013, 3, 18))
+  }
+
+  test("third Monday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Mon, Schedule.Third) should be(
+      LocalDate.of(2013, 4, 15))
+  }
+
+  test("third Tuesday of May 2013") {
+    Meetup(5, 2013).day(Meetup.Tue, Schedule.Third) should be(
+      LocalDate.of(2013, 5, 21))
+  }
+
+  test("third Tuesday of June 2013") {
+    Meetup(6, 2013).day(Meetup.Tue, Schedule.Third) should be(
+      LocalDate.of(2013, 6, 18))
+  }
+
+  test("third Wednesday of July 2013") {
+    Meetup(7, 2013).day(Meetup.Wed, Schedule.Third) should be(
+      LocalDate.of(2013, 7, 17))
+  }
+
+  test("third Wednesday of August 2013") {
+    Meetup(8, 2013).day(Meetup.Wed, Schedule.Third) should be(
+      LocalDate.of(2013, 8, 21))
+  }
+
+  test("third Thursday of September 2013") {
+    Meetup(9, 2013).day(Meetup.Thu, Schedule.Third) should be(
+      LocalDate.of(2013, 9, 19))
+  }
+
+  test("third Thursday of October 2013") {
+    Meetup(10, 2013).day(Meetup.Thu, Schedule.Third) should be(
+      LocalDate.of(2013, 10, 17))
+  }
+
+  test("third Friday of November 2013") {
+    Meetup(11, 2013).day(Meetup.Fri, Schedule.Third) should be(
+      LocalDate.of(2013, 11, 15))
+  }
+
+  test("third Friday of December 2013") {
+    Meetup(12, 2013).day(Meetup.Fri, Schedule.Third) should be(
+      LocalDate.of(2013, 12, 20))
+  }
+
+  test("third Saturday of January 2013") {
+    Meetup(1, 2013).day(Meetup.Sat, Schedule.Third) should be(
+      LocalDate.of(2013, 1, 19))
+  }
+
+  test("third Saturday of February 2013") {
+    Meetup(2, 2013).day(Meetup.Sat, Schedule.Third) should be(
+      LocalDate.of(2013, 2, 16))
+  }
+
+  test("third Sunday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Sun, Schedule.Third) should be(
+      LocalDate.of(2013, 3, 17))
+  }
+
+  test("third Sunday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Sun, Schedule.Third) should be(
+      LocalDate.of(2013, 4, 21))
+  }
+
+  test("fourth Monday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Mon, Schedule.Fourth) should be(
+      LocalDate.of(2013, 3, 25))
+  }
+
+  test("fourth Monday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Mon, Schedule.Fourth) should be(
+      LocalDate.of(2013, 4, 22))
+  }
+
+  test("fourth Tuesday of May 2013") {
+    Meetup(5, 2013).day(Meetup.Tue, Schedule.Fourth) should be(
+      LocalDate.of(2013, 5, 28))
+  }
+
+  test("fourth Tuesday of June 2013") {
+    Meetup(6, 2013).day(Meetup.Tue, Schedule.Fourth) should be(
+      LocalDate.of(2013, 6, 25))
+  }
+
+  test("fourth Wednesday of July 2013") {
+    Meetup(7, 2013).day(Meetup.Wed, Schedule.Fourth) should be(
+      LocalDate.of(2013, 7, 24))
+  }
+
+  test("fourth Wednesday of August 2013") {
+    Meetup(8, 2013).day(Meetup.Wed, Schedule.Fourth) should be(
+      LocalDate.of(2013, 8, 28))
+  }
+
+  test("fourth Thursday of September 2013") {
+    Meetup(9, 2013).day(Meetup.Thu, Schedule.Fourth) should be(
+      LocalDate.of(2013, 9, 26))
+  }
+
+  test("fourth Thursday of October 2013") {
+    Meetup(10, 2013).day(Meetup.Thu, Schedule.Fourth) should be(
+      LocalDate.of(2013, 10, 24))
+  }
+
+  test("fourth Friday of November 2013") {
+    Meetup(11, 2013).day(Meetup.Fri, Schedule.Fourth) should be(
+      LocalDate.of(2013, 11, 22))
+  }
+
+  test("fourth Friday of December 2013") {
+    Meetup(12, 2013).day(Meetup.Fri, Schedule.Fourth) should be(
+      LocalDate.of(2013, 12, 27))
+  }
+
+  test("fourth Saturday of January 2013") {
+    Meetup(1, 2013).day(Meetup.Sat, Schedule.Fourth) should be(
+      LocalDate.of(2013, 1, 26))
+  }
+
+  test("fourth Saturday of February 2013") {
+    Meetup(2, 2013).day(Meetup.Sat, Schedule.Fourth) should be(
+      LocalDate.of(2013, 2, 23))
+  }
+
+  test("fourth Sunday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Sun, Schedule.Fourth) should be(
+      LocalDate.of(2013, 3, 24))
+  }
+
+  test("fourth Sunday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Sun, Schedule.Fourth) should be(
+      LocalDate.of(2013, 4, 28))
+  }
+
+  test("last Monday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Mon, Schedule.Last) should be(
+      LocalDate.of(2013, 3, 25))
+  }
+
+  test("last Monday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Mon, Schedule.Last) should be(
+      LocalDate.of(2013, 4, 29))
+  }
+
+  test("last Tuesday of May 2013") {
+    Meetup(5, 2013).day(Meetup.Tue, Schedule.Last) should be(
+      LocalDate.of(2013, 5, 28))
+  }
+
+  test("last Tuesday of June 2013") {
+    Meetup(6, 2013).day(Meetup.Tue, Schedule.Last) should be(
+      LocalDate.of(2013, 6, 25))
+  }
+
+  test("last Wednesday of July 2013") {
+    Meetup(7, 2013).day(Meetup.Wed, Schedule.Last) should be(
+      LocalDate.of(2013, 7, 31))
+  }
+
+  test("last Wednesday of August 2013") {
+    Meetup(8, 2013).day(Meetup.Wed, Schedule.Last) should be(
+      LocalDate.of(2013, 8, 28))
+  }
+
+  test("last Thursday of September 2013") {
+    Meetup(9, 2013).day(Meetup.Thu, Schedule.Last) should be(
+      LocalDate.of(2013, 9, 26))
+  }
+
+  test("last Thursday of October 2013") {
+    Meetup(10, 2013).day(Meetup.Thu, Schedule.Last) should be(
+      LocalDate.of(2013, 10, 31))
+  }
+
+  test("last Friday of November 2013") {
+    Meetup(11, 2013).day(Meetup.Fri, Schedule.Last) should be(
+      LocalDate.of(2013, 11, 29))
+  }
+
+  test("last Friday of December 2013") {
+    Meetup(12, 2013).day(Meetup.Fri, Schedule.Last) should be(
+      LocalDate.of(2013, 12, 27))
+  }
+
+  test("last Saturday of January 2013") {
+    Meetup(1, 2013).day(Meetup.Sat, Schedule.Last) should be(
+      LocalDate.of(2013, 1, 26))
+  }
+
+  test("last Saturday of February 2013") {
+    Meetup(2, 2013).day(Meetup.Sat, Schedule.Last) should be(
+      LocalDate.of(2013, 2, 23))
+  }
+
+  test("last Sunday of March 2013") {
+    Meetup(3, 2013).day(Meetup.Sun, Schedule.Last) should be(
+      LocalDate.of(2013, 3, 31))
+  }
+
+  test("last Sunday of April 2013") {
+    Meetup(4, 2013).day(Meetup.Sun, Schedule.Last) should be(
+      LocalDate.of(2013, 4, 28))
+  }
+
+  test("last Wednesday of February 2012") {
+    Meetup(2, 2012).day(Meetup.Wed, Schedule.Last) should be(
+      LocalDate.of(2012, 2, 29))
+  }
+
+  test("last Wednesday of December 2014") {
+    Meetup(12, 2014).day(Meetup.Wed, Schedule.Last) should be(
+      LocalDate.of(2014, 12, 31))
+  }
+
+  test("last Sunday of February 2015") {
+    Meetup(2, 2015).day(Meetup.Sun, Schedule.Last) should be(
+      LocalDate.of(2015, 2, 22))
+  }
+
+  test("first Friday of December 2012") {
+    Meetup(12, 2012).day(Meetup.Fri, Schedule.First) should be(
+      LocalDate.of(2012, 12, 7))
+  }
+}


### PR DESCRIPTION
Introduced the `Meetup` class to calculate specific meetup dates based on the weekday and schedule (e.g., first, teenth, last). Added corresponding tests and project configuration files, including `build.sbt`, `build.properties`, and a detailed `README.md` explaining the exercise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to calculate specific dates within a month and year based on a chosen day of the week and scheduling rule (e.g., first Monday, last Friday, "teenth" Wednesday).
  - Introduced support for scheduling rules such as first, second, third, fourth, last, and "teenth" occurrences of a weekday within a month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->